### PR TITLE
Generate PDFs

### DIFF
--- a/.github/workflows/msys2-mingw64-actions-split.yml
+++ b/.github/workflows/msys2-mingw64-actions-split.yml
@@ -135,7 +135,7 @@ jobs:
   build-oolite-installers:
     name: Build Oolite installers
     runs-on: windows-latest
-    needs: [build-tools-make, build-libs-base, build-sdl, build-oolite]
+    needs: [build-tools-make, build-libs-base, build-sdl, build-oolite, generate-pdfs]
     defaults:
       run:
         shell: msys2 {0}
@@ -230,6 +230,12 @@ jobs:
       - name: Fail if cached data for Oolite is missing
         if: steps.restore-oolite.outputs.cache-hit != 'true'
         run: echo "Unable to restore Oolite files from previous job" && false
+
+      - name: Retrieve pdfs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pdfs
+          path: oolite/Doc
 
       - name: Build installers
         run: |
@@ -706,6 +712,53 @@ jobs:
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+
+########################################
+########################################
+########################################
+
+# Generate the PDFs of the Oolite documentation .odt files in the oolite/Doc/ folder
+
+# TODO
+# This currently runs every time the workflow is run.
+# Ideally we would cache the generated pdfs and only regenerate them if the .odt files have changed.
+# As it runs on ubuntu-latest we would set enableCrossOsArchive to true in the cache action.
+# The cache key should include the hash of oolite/Doc/ and the hash of this workflow file.
+# Unfortunately I cannot get the hash of either the oolite/Doc/ folder or the .odt files to match on both Ubuntu and Windows runners.
+# I suspect that the line endings are different on the two systems, but have failed to find a way to fix this.
+
+  generate-pdfs:
+    name: Generate PDFs
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+
+      - name: Checkout Oolite
+        uses: actions/checkout@v4
+        with:
+          repository: OoliteProject/oolite
+          path: oolite
+          sparse-checkout: Doc
+
+      - name: Install LibreOffice and Fonts 
+        run: |
+          sudo apt update
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt -y install libreoffice ttf-mscorefonts-installer
+
+      - name: Generate PDFs
+        run: |
+          find ./oolite/Doc -name "*.odt" -exec soffice --headless --convert-to pdf:"writer_pdf_Export" --outdir oolite/Doc {} \;
+
+      - name: Store pdfs as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdfs
+          path: ./oolite/Doc/*.pdf
+
 
 ########################################
 ########################################

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Should the caches be removed, this will not be a problem - caching between build
 - The from-fresh script downloads everything that it needs to build Oolite and all its dependencies; the GitHub Actions workflow will only download what it needs within each separate build job.
 - The from-fresh script only builds the release version of Oolite; the GitHub Actions workflow builds all versions of Oolite, and creates installers for all three release versions.
 - Once the from-fresh script has finished, you will have a fully functional development environment for Oolite which you can work with; Once the GitHub Actions workflow has finished, you will only be able to download the installers and read the build logs.
+- The from-fresh script does not generate the .pdf documentation from the .odt files; the GitHub Actions workflow generates these and they are included in the installed package.
 
 ## Roadmap
 


### PR DESCRIPTION
## Generate the PDF documentation

### Pull Request Type

- [x] Bug Fix
- [x] Documentation Update
- [x] New Feature

### Description

In the GitHub Actions build, this generates the .pdf documentation from the .odt files, uploads them as an artifact, and then downloads them so they can be used in the installed package.

### Checklist

- [x] Documentation has been updated to reflect the changes made in this pull request.
- [x] Code follows the project's coding conventions and style guidelines.

### Related Issues

#40 

### Additional Notes

The PDFs are generated every time the workflow is run.
Ideally we would cache the generated pdfs and only regenerate them if the .odt files have changed.
As it runs on ubuntu-latest we would set enableCrossOsArchive to true in the cache action.
The cache key should include the hash of oolite/Doc/ and the hash of this workflow file.
Unfortunately I cannot get the hash of either the oolite/Doc/ folder or the .odt files to match on both Ubuntu and Windows runners.
I suspect that the line endings are different on the two systems, but have failed to find a way to fix this.
