### PR TITLE
Split workflows

### DIFF
--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -872,10 +872,10 @@ jobs:
   check-oolite-ref:
     name: Check Oolite ref is valid
     runs-on: ubuntu-latest
-    if: ${{ inputs.oolite_ref != 'master' }}
 
     steps:
-      - name: Check if provided ref exists in Oolite repository
+      - name: Check if provided ref exists in Oolite repository (skip if ref is not 'master' and use the latest commit from the master branch)
+        if: ${{ inputs.oolite_ref != 'master' }}
         run: |
           if git ls-remote --exit-code https://github.com/OoliteProject/oolite.git ${{ inputs.oolite_ref }}
           then

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -874,7 +874,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if provided ref exists in Oolite repository (skip if ref is not 'master' and use the latest commit from the master branch)
+      - name: Check if provided ref exists in Oolite repository (skip if ref is 'master' and use the latest commit from the master branch)
         if: ${{ inputs.oolite_ref != 'master' }}
         run: |
           if git ls-remote --exit-code https://github.com/OoliteProject/oolite.git ${{ inputs.oolite_ref }}

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -814,7 +814,7 @@ jobs:
           bash ./oolite-from-fresh-msys2-mingw64.sh -b ${{ matrix.build_type }} -r ${{ inputs.oolite_ref }}
 
       - name: Run build script with latest commit on Oolite master
-        if: ${{ inputs.oolite_ref == '' }}
+        if: ${{ inputs.oolite_ref == 'master' }}
         run: |
           bash ./oolite-from-fresh-msys2-mingw64.sh -b ${{ matrix.build_type }}
 

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -872,10 +872,10 @@ jobs:
   check-oolite-ref:
     name: Check Oolite ref is valid
     runs-on: ubuntu-latest
+    if: ${{ inputs.oolite_ref != 'master' }}
 
     steps:
-      - name: Check if provided ref exists in Oolite repository (skip if ref is not 'master' and use the latest commit from the master branch)
-        if: ${{ inputs.oolite_ref != 'master' }}
+      - name: Check if provided ref exists in Oolite repository
         run: |
           if git ls-remote --exit-code https://github.com/OoliteProject/oolite.git ${{ inputs.oolite_ref }}
           then

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -2,7 +2,7 @@
 
 name: Build Oolite on MSYS2-MINGW64
 on: 
-  workflow_dispatch:
+  workflow_call:
     inputs:
       run_tests:
         description: Run build tests
@@ -19,10 +19,6 @@ on:
         required: false
         type: string
         default: master
-  pull_request:
-  push:
-    branches:
-      - main
 jobs:
 
 ########################################
@@ -821,23 +817,6 @@ jobs:
         if: ${{ inputs.oolite_ref == '' }}
         run: |
           bash ./oolite-from-fresh-msys2-mingw64.sh -b ${{ matrix.build_type }}
-
-########################################
-########################################
-########################################
-
-# Run Shellcheck to lint the scripts
-
-  shellcheck:
-    name: Run ShellCheck
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout this repository
-        uses: actions/checkout@v4
-
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
 
 ########################################
 ########################################

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -6,17 +6,17 @@ on:
     inputs:
       run_tests:
         description: Run build tests
-        required: false
+        required: true
         type: boolean
         default: false
       from_fresh:
         description: Build all dependencies from scratch
-        required: false
+        required: true
         type: boolean
         default: false
       oolite_ref:
         description: The version of Oolite to build
-        required: false
+        required: true
         type: string
         default: master
 jobs:
@@ -809,7 +809,7 @@ jobs:
           update: true
 
       - name: Run build script with provided Oolite ref
-        if: ${{ inputs.oolite_ref != '' }}
+        if: ${{ inputs.oolite_ref != 'master' }}
         run: |
           bash ./oolite-from-fresh-msys2-mingw64.sh -b ${{ matrix.build_type }} -r ${{ inputs.oolite_ref }}
 
@@ -874,8 +874,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if provided ref exists in Oolite repository (skip if ref is not provided and use the latest commit from the master branch)
-        if: ${{ inputs.oolite_ref != '' }}
+      - name: Check if provided ref exists in Oolite repository (skip if ref is not 'master' and use the latest commit from the master branch)
+        if: ${{ inputs.oolite_ref != 'master' }}
         run: |
           if git ls-remote --exit-code https://github.com/OoliteProject/oolite.git ${{ inputs.oolite_ref }}
           then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+# Workflow to call on commits and PRs
+
+name: CI
+on: 
+  workflow_dispatch:
+    inputs:
+      run_tests:
+        description: Run build tests
+        required: false
+        type: boolean
+        default: false
+      from_fresh:
+        description: Build all dependencies from scratch
+        required: false
+        type: boolean
+        default: false
+      oolite_ref:
+        description: The version of Oolite to build
+        required: false
+        type: string
+        default: master
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+
+########################################
+########################################
+########################################
+
+  test-repo:
+    uses: ./.github/workflows/test-repo.yml
+
+########################################
+
+  build-oolite:
+    uses: ./.github/workflows/build-oolite.yml
+    needs: test-repo
+    with:
+      run_tests: ${{ inputs.run_tests }}
+      from_fresh: ${{ inputs.from_fresh }}
+      oolite_ref: ${{ inputs.oolite_ref }}
+
+########################################
+########################################
+########################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
 
   build-oolite:
     uses: ./.github/workflows/build-oolite.yml
-    needs: test-repo
     with:
       run_tests: ${{ inputs.run_tests }}
       from_fresh: ${{ inputs.from_fresh }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
   build-oolite:
     uses: ./.github/workflows/build-oolite.yml
     with:
-      run_tests: ${{ inputs.run_tests }}
-      from_fresh: ${{ inputs.from_fresh }}
-      oolite_ref: ${{ inputs.oolite_ref }}
+      run_tests: ${{ inputs.run_tests || false }}
+      from_fresh: ${{ inputs.from_fresh || false }}
+      oolite_ref: ${{ inputs.oolite_ref || 'master' }}
 
 ########################################
 ########################################

--- a/.github/workflows/test-repo.yml
+++ b/.github/workflows/test-repo.yml
@@ -1,0 +1,27 @@
+# Workflow to test the repository
+
+name: Test repository
+on:
+  workflow_call:
+jobs:
+
+########################################
+########################################
+########################################
+
+# Run Shellcheck to lint the scripts
+
+  shellcheck:
+    name: Run ShellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
+########################################
+########################################
+########################################


### PR DESCRIPTION
## Split workflows

### Pull Request Type

- [x] New Feature

### Description

Splits the workflows so that testing the repository and building Oolite are separate concerns.

### Related Issues

#67 