### PR TITLE
Workflow bug fixes

### DIFF
--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -1,4 +1,26 @@
 # Workflow to compile Oolite and necessary dependencies
+# This is not run directly, but is called by other workflows.
+# It is designed to be run on a Windows runner and uses MSYS2-MINGW64 to compile Oolite.
+
+# The workflow is triggered by a workflow_call event.
+# The event has three required inputs:
+# - run_tests: A boolean to determine if the tests should be run on the built dependencies (if they exist).
+# - from_fresh: A boolean to determine whether to force the dependencies to be built from scratch and not use a cached version.
+# - oolite_ref: A string to specify the version of Oolite to build. This can be a branch or a tag. Commit hashes are not yet supported.
+
+# The workflow is split into several jobs:
+# - build-oolite: This job checks out the Oolite repository, checks out the specified ref, compiles Oolite, and caches the build.
+# - build-oolite-installers: This job uses the caches from the successful build-oolite job and compiles the Oolite installers.
+# - build-tools-make: This job checks out the tools-make repository, compiles tools-make, and caches the build.
+# - build-libs-base: This job checks out the libs-base repository, compiles libs-base, and caches the build.
+# - build-sdl: This job downloads and compiles SDL, and caches the build.
+# - build-espeak: This job downloads and compiles eSpeak, and caches the build.
+# - test-libs-base: This job uses the cache from the successful build-libs-base job and runs the tests on the built library.
+# - test-sdl: This job uses the cache from the successful build-sdl job and runs the tests on the built library
+# - clear-oolite-caches: This job deletes any caches created by the build-oolite job.
+# - build-oolite-from-fresh-msys2-mingw64: This job is a single script to build Oolite from scratch. It is used to test the from-fresh script.
+# - generate-pdfs: This job generates the PDFs of the Oolite documentation .odt files in the oolite/Doc/ folder.
+# - check-oolite-ref: This job checks if the provided ref exists in the Oolite repository. Commit hashes are not yet supported.
 
 name: Build Oolite on MSYS2-MINGW64
 on: 
@@ -670,7 +692,10 @@ jobs:
 ########################################
 ########################################
 
-# Clear unnecessary caches on GitHub
+# Clear unnecessary Oolite caches on GitHub
+
+# The Oolite caches are only intended to be used in the current workflow run.
+# We delete them after the workflow has completed to avoid unnecessary storage usage.
 
   clear-oolite-caches:
     name: Clear Oolite caches
@@ -779,6 +804,14 @@ jobs:
 ########################################
 ########################################
 ########################################
+
+# Check if the provided ref exists in the Oolite repository
+
+# TODO
+# This uses git ls-remote to check if the provided ref exists in the Oolite repository.
+# Branches and tags are supported.
+# Commit hashes can not be detected by git ls-remote. We need to find an alternative way to check if a commit hash exists in the remote repository.
+# While actions/checkout@v4 supports checking out from a commit hash, we cannot use them until we have a way to confirm that it is a valid commit.
 
   check-oolite-ref:
     name: Check Oolite ref is valid

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: tools-make
-          key: cache-tools-make-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/tools-make/*') }}
+          key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -81,7 +81,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: libs-base
-          key: cache-libs-base-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
+          key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -99,7 +99,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: SDL-1.2.13
-          key: cache-sdl-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/sdl/*') }}
+          key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: espeak-1.43.03-source
-          key: cache-espeak-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/espeak/*') }}
+          key: cache-espeak-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/espeak/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -188,7 +188,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: tools-make
-          key: cache-tools-make-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/tools-make/*') }}
+          key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -206,7 +206,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: libs-base
-          key: cache-libs-base-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
+          key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -224,7 +224,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: SDL-1.2.13
-          key: cache-sdl-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/sdl/*') }}
+          key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -242,7 +242,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: espeak-1.43.03-source
-          key: cache-espeak-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/espeak/*') }}
+          key: cache-espeak-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/espeak/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -319,7 +319,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: tools-make
-          key: cache-tools-make-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/tools-make/*') }}
+          key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           lookup-only: true
 
       - name: Early exit if cache exists and not building from fresh
@@ -356,14 +356,14 @@ jobs:
         shell: bash
         run: |
           echo "Deleting pre-existing cache" >> $GITHUB_STEP_SUMMARY
-          gh cache delete cache-tools-make-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/tools-make/*') }}
+          gh cache delete cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
 
       - name: Cache tools-make build
         if: steps.early-exit.conclusion != 'success'
         uses: actions/cache/save@v4
         with:
           path: tools-make
-          key: cache-tools-make-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/tools-make/*') }}
+          key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
 
 ########################################
 
@@ -394,7 +394,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: libs-base
-          key: cache-libs-base-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
+          key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
           lookup-only: true
 
       - name: Early exit if cache exists and not building from fresh
@@ -419,7 +419,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: tools-make
-          key: cache-tools-make-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/tools-make/*') }}
+          key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -451,14 +451,14 @@ jobs:
         shell: bash
         run: |
           echo "Deleting pre-existing cache" >> $GITHUB_STEP_SUMMARY
-          gh cache delete cache-libs-base-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
+          gh cache delete cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
 
       - name: Cache libs-base build
         if: steps.early-exit.conclusion != 'success'
         uses: actions/cache/save@v4
         with:
           path: libs-base
-          key: cache-libs-base-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
+          key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
 
 ########################################
 
@@ -489,7 +489,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: SDL-1.2.13
-          key: cache-sdl-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/sdl/*') }}
+          key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
           lookup-only: true
 
       - name: Early exit if cache exists and not building from fresh
@@ -524,14 +524,15 @@ jobs:
         shell: bash
         run: |
           echo "Deleting pre-existing cache" >> $GITHUB_STEP_SUMMARY
-          gh cache delete cache-sdl-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/sdl/*') }}
+          gh cache delete cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
 
       - name: Cache SDL build
         if: steps.early-exit.conclusion != 'success'
         uses: actions/cache/save@v4
         with:
           path: SDL-1.2.13
-          key: cache-sdl-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/sdl/*') }}
+          key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
+
 ########################################
 
   build-espeak:
@@ -561,7 +562,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: espeak
-          key: cache-espeak-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/espeak/*') }}
+          key: cache-espeak-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/espeak/*') }}
           lookup-only: true
 
       - name: Early exit if cache exists and not building from fresh
@@ -596,14 +597,14 @@ jobs:
         shell: bash
         run: |
           echo "Deleting pre-existing cache" >> $GITHUB_STEP_SUMMARY
-          gh cache delete cache-espeak-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/espeak/*') }}
+          gh cache delete cache-espeak-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/espeak/*') }}
 
       - name: Cache eSpeak build
         if: steps.early-exit.conclusion != 'success'
         uses: actions/cache/save@v4
         with:
           path: espeak-1.43.03-source
-          key: cache-espeak-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/espeak/*') }}
+          key: cache-espeak-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/espeak/*') }}
 
 ########################################
 ########################################
@@ -645,7 +646,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: tools-make
-          key: cache-tools-make-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/tools-make/*') }}
+          key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -663,7 +664,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: libs-base
-          key: cache-libs-base-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
+          key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
@@ -724,7 +725,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: SDL-1.2.13
-          key: cache-sdl-${{ hashFiles('**/.github/workflows/msys2-mingw64-actions-split.yml', '**/deps/sdl/*') }}
+          key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
           fail-on-cache-miss: true
 
       # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -684,25 +684,13 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v4
 
-      - name: List all caches
-        run: |
-          gh cache list
-
       - name: List Oolite caches created by this workflow run
         run: |
           gh cache list | grep cache-oolite-${{ github.run_id }}-${{ github.run_attempt }} | awk '{print $2}' > cache-list.txt
-          cat cache-list.txt
-
-      - name: Delete Oolite caches created by this workflow run
-        run: |
           foreach ($cache in Get-Content cache-list.txt) {
-            echo $cache
+            echo "Deleting cache $cache"
             gh cache delete $cache
           }
-
-      - name: List all remaining caches
-        run: |
-          gh cache list
 
 ########################################
 ########################################

--- a/.github/workflows/build-oolite.yml
+++ b/.github/workflows/build-oolite.yml
@@ -66,12 +66,6 @@ jobs:
           key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for tools-make is missing
-        if: steps.restore-tools-make.outputs.cache-hit != 'true'
-        run: echo "Unable to restore tools-make files from previous job" && false
-
       - name: Install tools-make
         run: |
           bash ./deps/tools-make/install.sh
@@ -83,12 +77,6 @@ jobs:
           path: libs-base
           key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
-
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for libs-base is missing
-        if: steps.restore-libs-base.outputs.cache-hit != 'true'
-        run: echo "Unable to restore libs-base files from previous job" && false
 
       - name: Install libs-base
         run: |
@@ -102,12 +90,6 @@ jobs:
           key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
           fail-on-cache-miss: true
 
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for SDL is missing
-        if: steps.restore-sdl.outputs.cache-hit != 'true'
-        run: echo "Unable to restore SDL files from previous job" && false
-
       - name: Install SDL
         run: |
           bash ./deps/sdl/install.sh
@@ -119,12 +101,6 @@ jobs:
           path: espeak-1.43.03-source
           key: cache-espeak-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/espeak/*') }}
           fail-on-cache-miss: true
-
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for eSpeak is missing
-        if: steps.restore-eSpeak.outputs.cache-hit != 'true'
-        run: echo "Unable to restore eSpeak files from previous job" && false
 
       - name: Install eSpeak
         run: |
@@ -191,16 +167,10 @@ jobs:
           key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for tools-make is missing
-        if: steps.restore-tools-make.outputs.cache-hit != 'true'
-        run: echo "Unable to restore tools-make files from previous job" && false
-    
       - name: Install tools-make
         run: |
           bash ./deps/tools-make/install.sh
-          
+
       - name: Retrieve libs-base cache
         id: restore-libs-base
         uses: actions/cache/restore@v4
@@ -208,12 +178,6 @@ jobs:
           path: libs-base
           key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
-
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for libs-base is missing
-        if: steps.restore-libs-base.outputs.cache-hit != 'true'
-        run: echo "Unable to restore libs-base files from previous job" && false
 
       - name: Install libs-base
         run: |
@@ -227,16 +191,10 @@ jobs:
           key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
           fail-on-cache-miss: true
 
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for SDL is missing
-        if: steps.restore-sdl.outputs.cache-hit != 'true'
-        run: echo "Unable to restore SDL files from previous job" && false
-
       - name: Install SDL
         run: |
           bash ./deps/sdl/install.sh
-          
+
       - name: Retrieve eSpeak cache
         id: restore-espeak
         uses: actions/cache/restore@v4
@@ -244,12 +202,6 @@ jobs:
           path: espeak-1.43.03-source
           key: cache-espeak-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/espeak/*') }}
           fail-on-cache-miss: true
-
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for eSpeak is missing
-        if: steps.restore-eSpeak.outputs.cache-hit != 'true'
-        run: echo "Unable to restore eSpeak files from previous job" && false
 
       - name: Install eSpeak
         run: |
@@ -262,12 +214,6 @@ jobs:
           path: oolite
           key: cache-oolite-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.build_type }}
           fail-on-cache-miss: true
-
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for Oolite is missing
-        if: steps.restore-oolite.outputs.cache-hit != 'true'
-        run: echo "Unable to restore Oolite files from previous job" && false
 
       - name: Retrieve pdfs artifact
         uses: actions/download-artifact@v4
@@ -421,12 +367,6 @@ jobs:
           path: tools-make
           key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
-
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for tools-make is missing
-        if: steps.early-exit.conclusion != 'success' && steps.restore-tools-make.outputs.cache-hit != 'true'
-        run: echo "Unable to restore tools-make files from previous job" && false
 
       - name: Install tools-make
         if: steps.early-exit.conclusion != 'success'
@@ -649,12 +589,6 @@ jobs:
           key: cache-tools-make-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
 
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for tools-make is missing
-        if: steps.restore-tools-make.outputs.cache-hit != 'true'
-        run: echo "Unable to restore tools-make files from previous job" && false
-
       - name: Install tools-make
         run: |
           bash ./deps/tools-make/install.sh
@@ -666,12 +600,6 @@ jobs:
           path: libs-base
           key: cache-libs-base-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/libs-base/*', '**/deps/tools-make/*') }}
           fail-on-cache-miss: true
-
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for libs-base is missing
-        if: steps.restore-libs-base.outputs.cache-hit != 'true'
-        run: echo "Unable to restore libs-base files from previous job" && false
 
       - name: Install libs-base
         run: |
@@ -727,12 +655,6 @@ jobs:
           path: SDL-1.2.13
           key: cache-sdl-${{ hashFiles('**/.github/workflows/build-oolite.yml', '**/deps/sdl/*') }}
           fail-on-cache-miss: true
-
-      # NOTE: fail-on-cache-miss does not correctly fail the job. This is a workaround.
-      # There is an open bug report for it here: https://github.com/actions/cache/issues/1265
-      - name: Fail if cached data for SDL is missing
-        if: steps.restore-sdl.outputs.cache-hit != 'true'
-        run: echo "Unable to restore SDL files from previous job" && false
 
       - name: Install SDL
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 # Workflow to call on commits and PRs
 
+# This workflow is triggered on pushes to the main branch and pull requests, as well as manually via the GitHub Actions UI. 
+# It calls both the test-repo and build-oolite workflows.
+# If it is triggered by a workflow_dispatch event, it will pass those parameters to the build-oolite workflow.
+# Otherwise, it calls the build-oolite workflow with inputs to compile Oolite from the master branch, without running tests, and using pre-existing caches if available.
+
 name: CI
 on: 
   workflow_dispatch:

--- a/.github/workflows/schedule-oolite-build.yml
+++ b/.github/workflows/schedule-oolite-build.yml
@@ -19,11 +19,6 @@ jobs:
       has_commits: ${{ steps.query_commits.outputs.has_commits }}
 
     steps:
-      - name: Install jq
-        run: |
-          sudo apt update
-          sudo apt-get install jq
-
       - name: Query recent Oolite commits
         id: query_commits
         run: |

--- a/.github/workflows/schedule-oolite-build.yml
+++ b/.github/workflows/schedule-oolite-build.yml
@@ -4,7 +4,7 @@
 # It will only compile Oolite if there have been commits to the master branch of OoliteProject/oolite in the last 24 hours.
 
 # The workflow is split into two jobs:
-# - check-recent-oolite-commits: This job queries the GitHub API for recent commits to OoliteProject/oolite.
+# - check-recent-oolite-commits: This job queries the GitHub API for recent commits to the master branch of OoliteProject/oolite.
 # - build-oolite: This job compiles Oolite if the check-recent-oolite-commits job found that there have been commits in the last 24 hours.
 
 name: Schedule Oolite Build
@@ -19,7 +19,7 @@ jobs:
 ########################################
 ########################################
 
-# Query the GitHub API for recent commits to OoliteProject/oolite.
+# Query the GitHub API for recent commits to the master branch of OoliteProject/oolite.
 # If there have been commits in the last 24 hours, set an output variable has_commits to true.
 
   check-recent-oolite-commits:
@@ -31,8 +31,8 @@ jobs:
       - name: Query recent Oolite commits
         id: query_commits
         run: |
-          curl -s "https://api.github.com/repos/OoliteProject/oolite/commits?since=$(date -d '24 hours ago' --iso-8601=seconds)" > commits.json
-          if [ $(jq length commits.json) -gt 0 ]; then
+          curl -s "https://api.github.com/repos/OoliteProject/oolite/commits?since=$(date -d '24 hours ago' --iso-8601=seconds)&sha=master" > commits.json
+          if [ $(jq length "commits.json") -gt 0 ]; then
             echo "has_commits=true" >> $GITHUB_OUTPUT
           else
             echo "has_commits=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/schedule-oolite-build.yml
+++ b/.github/workflows/schedule-oolite-build.yml
@@ -1,5 +1,11 @@
-# Workflow to compile Oolite each day at 3:14 AM
-# Will only compile if there have been commits in the last 24 hours
+# Workflow to schedule a daily Oolite build
+
+# The workflow is triggered by a cron schedule, and runs at 3:14 AM each day.
+# It will only compile Oolite if there have been commits to the master branch of OoliteProject/oolite in the last 24 hours.
+
+# The workflow is split into two jobs:
+# - check-recent-oolite-commits: This job queries the GitHub API for recent commits to OoliteProject/oolite.
+# - build-oolite: This job compiles Oolite if the check-recent-oolite-commits job found that there have been commits in the last 24 hours.
 
 name: Schedule Oolite Build
 
@@ -12,6 +18,9 @@ jobs:
 ########################################
 ########################################
 ########################################
+
+# Query the GitHub API for recent commits to OoliteProject/oolite.
+# If there have been commits in the last 24 hours, set an output variable has_commits to true.
 
   check-recent-oolite-commits:
     runs-on: ubuntu-latest
@@ -30,6 +39,9 @@ jobs:
           fi
 
 ########################################
+
+# If check-recent-oolite-commits found that there have been commits in the last 24 hours, run the build-oolite job.
+# This calls the build-oolite workflow with inputs to compile Oolite from the master branch, without running tests, and using pre-existing caches if available.
 
   build-oolite:
     needs: check-recent-oolite-commits

--- a/.github/workflows/test-repo.yml
+++ b/.github/workflows/test-repo.yml
@@ -1,4 +1,13 @@
-# Workflow to test the repository
+# Workflow to test the oolite-msys2 repository
+# This is not run directly, but is called by other workflows.
+
+# This workflow is triggered by a workflow_call event
+
+# The workflow currently contains one job:
+# - shellcheck: Runs ShellCheck to check all the bash scripts
+
+# TODO
+# Add jobs to test the workflow actions.
 
 name: Test repository
 on:


### PR DESCRIPTION
## Workflow bug fixes

### Pull Request Type

- [x] Bug Fix
- [x] Documentation Update

### Description

- `jq` is already installed on ubuntu runner, so no need to query `apt` and install
- Fix the cache keys - when the workflow was split I did not update the hashfile of the workflow
- Remove the workaround for the fail-on-cache-miss bug now that it has been fixed upstream
- Remove the unnecessary debug printing of lists in the clear-oolite-caches job
- Add comments to better document the workflows
- Make the cron job check Oolite's master branch for commits, rather than to the whole repository

### Checklist

- [x] Code follows the project's coding conventions and style guidelines.
